### PR TITLE
決済前のクレジットカード登録方法変更

### DIFF
--- a/app/assets/stylesheets/items/index.scss
+++ b/app/assets/stylesheets/items/index.scss
@@ -12,6 +12,7 @@ a {
 }
 /* 背景 */
 .wrapper{
+  width: 100vw;
   height: 100vh;
   padding-top: 90px;
   background-color: #fffafafa;

--- a/app/assets/stylesheets/order/new_card.css
+++ b/app/assets/stylesheets/order/new_card.css
@@ -1,0 +1,68 @@
+/* aタグ共有 */
+a {
+  text-decoration: none;
+}
+/* ヘッダー共有ブロック */
+.header {
+  position: fixed;
+  top: 0px;
+  width: 100vw;
+  border-bottom: 1px rgba(0, 0, 0, 0.253) solid;
+  background-color:#ffffff;
+}
+/* 背景 */
+.wrapper{
+  height: 100vh;
+  padding-top: 90px;
+  background-color: #fffafafa;
+  overflow: hidden;
+  overflow: scroll;
+}
+.order-new-card-container {
+  margin: 100px 0px;
+  padding: 0px 200px; 
+  display: flex;
+  justify-content: center;
+}
+
+.order-new-card-field {
+  box-shadow: 3px 3px 3px gray;
+  background-color: white;
+  width: 700px;
+  padding: 50px 20px ;
+}
+.user-form-wraps {
+  margin: auto;
+  width: 350px;
+  display: flex;
+  flex-direction: column;
+}
+.card-form-title {
+  text-align: center;
+  font-size: 30px;
+  height: 50px;
+}
+.card-brand-image {
+  display: flex;
+  justify-content: space-evenly;
+  height: 35px;
+  margin-bottom: 20px;
+}
+.card-logo {
+  width: 50px;
+}
+
+.card-form-wrap {
+  margin-top: 50px;
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px #ccc solid;
+}
+.card-form-text {
+  width: 100px;
+}
+.card-form {
+  text-align: center;
+  border: none;
+  outline: none;
+}

--- a/app/assets/stylesheets/user/edit.css
+++ b/app/assets/stylesheets/user/edit.css
@@ -53,7 +53,6 @@ a {
 /* edit専用 */
 .user-edit-form-container {
   background-color: white;
-  width: 600px;
   margin: auto;
   margin-top: 50px;
   margin-bottom: 50px;

--- a/app/assets/stylesheets/user/show.scss
+++ b/app/assets/stylesheets/user/show.scss
@@ -29,7 +29,7 @@ a {
 /* サイドバー */
 .user-show-sidebar {
   background-color: white;
-  width: 300px;
+  width: 250px;
   box-shadow: 3px 3px 3px gray;
 }
 .user-info-content{

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -31,5 +31,5 @@ const card = () =>{
   });
 };
 // クレジットカード入力ページなら実行
-if (document.URL.match("/card/new")){
+if (document.URL.match("/card/new") || document.URL.match("/order/new_card")) {
 window.addEventListener('load', card)};

--- a/app/views/cards/new.html.erb
+++ b/app/views/cards/new.html.erb
@@ -3,11 +3,10 @@
 </div>
 
 <div class="wrapper">
-  
   <div class="user-show-container">
+
     <%# サイドバー %>
     <%= render "users/shared/user_side.html.erb"%>
-      
       
     <%# メインフィールド %>
     
@@ -48,8 +47,6 @@
 
         </div>
       </div>
-    </div>
-
     </div>
   </div>
 </div>

--- a/app/views/orders/new_card.html.erb
+++ b/app/views/orders/new_card.html.erb
@@ -1,0 +1,47 @@
+<div class="header">
+  <%= render "shared/header.html.erb"%>
+</div>
+
+<div class="wrapper">
+  <div class="order-new-card-container">
+
+    
+    
+    <div class="order-new-card-field">
+        <div class="user-form-wraps">
+          <%# タイトル %>
+          <div class="card-form-title">カード情報</div>
+          <div class="card-brand-image">
+            <%= image_tag "card-amex.gif", class:"card-logo" %>
+            <%= image_tag "card-jcb.gif", class:"card-logo" %>
+            <%= image_tag "card-mastercard.gif", class:"card-logo" %>
+            <%= image_tag "card-visa.gif", class:"card-logo"%>
+          </div>
+
+          <%# クレジットカード入力フォーム %>
+          <%= form_with  url: create_card_item_order_path(@item), id: 'customer_form', local: true do |f| %>
+            <div class="card-form-wrap">
+                <label class="card-form-text">カード番号</label>
+                <%= f.text_field :number, class: "card-form", maxlength: "16", placeholder: "1234567812345678",style: "width: 16em", autofocus: true %> 
+            </div>
+
+            <div class="card-form-wrap", style="width: 150px">
+                <label class="card-form-text">有効期限</label>
+                <%= f.text_field :exp_month,maxlength: "2", class: "card-form" ,placeholder: "12"%><span>/</span>
+                <%= f.text_field :exp_year,maxlength: "2", class: "card-form" ,placeholder: "24"%>
+            </div>
+
+            <div class="card-form-wrap" style="width: 150px">
+                <label class="card-form-text">CVC番号</label>
+                <%= f.text_field :cvc, maxlength: "4",class: "card-form", placeholder: "CVC" %>
+            </div>
+
+            <div class="user-edit-form-submit">
+              <%= f.submit "登録する", class: "user-form-btn"%>
+            </div>
+          <% end %>
+
+        </div>
+      </div>
+  </div>
+</div>

--- a/app/views/orders/select_card.html.erb
+++ b/app/views/orders/select_card.html.erb
@@ -38,9 +38,9 @@
             <% end %>
         <% end %>
         <div class="card-add-btn">
-          <%= link_to "＋クレジットカードを追加", new_user_card_path(@user.id) %>
+          <%= link_to "＋クレジットカードを追加", new_card_item_order_path(@item.id) %>
         </div>
-
+        
         <div class="order-next">
           <%= f.submit "次へ進む", class:"order-next-btn" %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
         post :set_address
         get :edit_address
         patch :update_address
+        get :new_card
+        post :create_card
       end
       
     end


### PR DESCRIPTION
#What

決済前のクレジットカード登録用ページ遷移の変更

#Why

# 決済前にクレジットカードの追加をするときマイページの入力フォームに遷移しないようにするため

