### PR TITLE
コメントdestroyアクションの修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,7 +10,7 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment = Comment.find(params[:id])
-    @comment.delete
+    @comment.destroy
   end
 
   private

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,8 +1,8 @@
 class Comment < ApplicationRecord
   belongs_to :item
   belongs_to :borrower, class_name: "User", foreign_key: "borrower_id"
-  has_many :nofitications, dependent: :destroy
-
+  has_many   :notifications, dependent: :destroy
+            
   validates :text, length:{maximum: 120}, presence: true
 
   

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,6 +1,7 @@
 class Order < ApplicationRecord
   belongs_to :borrower, class_name: "User", foreign_key: "borrower_id"
   belongs_to :item
+  belongs_to :notification, dependent: :destroy
 
   with_options presence: true do
     validates :piece, numericality:{ greater_than: 0 }


### PR DESCRIPTION
#What

コメントdestroyアクションの修正

#Why

dependent:destroyが無効になってしまったため